### PR TITLE
[platform] [mellanox] Use correct API call to update firmware in auto_update_firmware

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -351,7 +351,7 @@ class Component(ComponentBase):
             return FW_AUTO_ERR_IMAGE
 
         if boot_action in default_supported_boot:
-            if self.install_firmware(image_path):
+            if self.update_firmware(image_path):
                 # Successful update
                 return FW_AUTO_INSTALLED
             # Failed update (unknown reason)
@@ -520,7 +520,7 @@ class ComponentSSD(Component):
             return FW_AUTO_ERR_UKNOWN
 
         if boot_action in supported_boot:
-            if self.install_firmware(image_path):
+            if self.update_firmware(image_path):
                 # Successful update
                 return FW_AUTO_INSTALLED
             # Failed update (unknown reason)


### PR DESCRIPTION
#### Why I did it

The `fwutil update all` utility expects the `auto_update_firmware` method in the Platform API to execute the `update_firmware()` call and not the `install_firmware()` call.

#### How I did it

Changed the method in the mellanox platform API component implementation. 

#### How to verify it

Run `fwutil update all` with a CPLD update on a Mellanox platform and verify that it properly updates the firmware using the MPFA file. 

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
[platform] [mellanox] Use correct API call to update firmware in auto_update_firmware


#### A picture of a cute animal (not mandatory but encouraged)
![RedPandaFullBody](https://user-images.githubusercontent.com/5898707/136500610-7f19d3fe-6fa9-4bb8-ab8f-e3d58e6e64ac.JPG)

