### PR TITLE
[mellanox] Add patch to hw-mgmt to prevent loading of non-existant kernel modules

### DIFF
--- a/platform/mellanox/hw-management/0003-Remove-unused-non-upstream-kernel-modules-from-load.patch
+++ b/platform/mellanox/hw-management/0003-Remove-unused-non-upstream-kernel-modules-from-load.patch
@@ -1,0 +1,25 @@
+From 14b06a12802fc0e15116a64f419d002d0d21d695 Mon Sep 17 00:00:00 2001
+From: Alexander Allen <arallen@nvidia.com>
+Date: Thu, 17 Feb 2022 04:19:50 +0000
+Subject: [PATCH] Remove unused non-upstream kernel modules from load
+
+---
+ usr/etc/modules-load.d/05-hw-management-modules.conf | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/usr/etc/modules-load.d/05-hw-management-modules.conf b/usr/etc/modules-load.d/05-hw-management-modules.conf
+index 39f621e..c0980bc 100644
+--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
++++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
+@@ -15,8 +15,6 @@ xdpe12284
+ mp2975
+ mp2888
+ i2c-mux-pca954x
+-emc2305
+-ads1015
+ powr1220
+ gpio-pca953x
+ pmbus
+-- 
+2.17.1
+


### PR DESCRIPTION
#### Why I did it

The latest upgrade of Mellanox hw-mgmt V7.0020.1300 introduced a couple new kernel modules for new Mellanox platforms that have yet to be upstreamed to the linux kernel. 

As these new platforms do not have SONiC support we elected not to upstream these new drivers to sonic-linux-kernel but hw-mgmt expects them to exist which is causing a non-functional error on switch boot. 

```
Feb 15 00:09:55.374130 r-leopard-simx-74 ERR systemd-modules-load[269]: Failed to find module 'emc2305'
Feb 15 00:09:55.374141 r-leopard-simx-74 ERR systemd-modules-load[269]: Failed to find module 'ads1015'
```

To resolve this we can patch hw-mgmt to no longer attempt to load these modules by default. 

#### How I did it

Added a SONiC patch to Mellanox hw-mgmt in order to remove the unused kernel modules which were not upstreamed to sonic-linux-kernel

#### How to verify it

Boot switch and verify there are no error logs regarding kernel modules failing to load. 

#### Which release branch to backport (provide reason below if selected)

Backport to 20211 as the relevant hw-mgmt and kernel changes that cause this bug are also on 202111

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
[mellanox] Add patch to hw-mgmt to prevent loading of non-existant kernel modules

#### A picture of a cute animal (not mandatory but encouraged)
![pX21jrN-asset-mezzanine-16x9-7xfdMiZ](https://user-images.githubusercontent.com/5898707/154405566-2aa36fe1-eb91-43d9-ad39-9bb04f9529da.jpg)

