### PR TITLE
Fix build dependencies for saithriftv2 in bullseye

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -64,6 +64,8 @@ RUN apt-get update && apt-get install -y \
         dh-make \
         dh-exec \
         kmod \
+        python-all \
+        python-all-dev \
         libtinyxml2-dev \
         python-all \
         python-dev \
@@ -79,6 +81,9 @@ RUN apt-get update && apt-get install -y \
         perl-modules \
         libclass-accessor-perl \
         libswitch-perl \
+        libtemplate-perl \
+        libmoose-perl \
+        libmoosex-aliases-perl \
         libzmq5 \
         libzmq3-dev \
         jq \

--- a/src/thrift_0_14_1/thrift.patch/0001-Remove-unneeded-packages.patch
+++ b/src/thrift_0_14_1/thrift.patch/0001-Remove-unneeded-packages.patch
@@ -19,7 +19,7 @@ index a9e934f17..752076582 100644
 -    erlang-base, ruby-dev | ruby1.9.1-dev, ruby-bundler ,autoconf, automake,
 -    pkg-config, libtool, bison, flex, libboost-dev | libboost1.56-dev | libboost1.63-all-dev,
 -    python-all, python-setuptools, python-all-dev, python-all-dbg,
-+Build-Depends: debhelper (>= 9), build-essential, python-dev,
++Build-Depends: debhelper (>= 9), build-essential,
 +    autoconf, automake,
 +    pkg-config, libtool,
 +    python-all, python-setuptools, python-all-dev,


### PR DESCRIPTION
#### Why I did it

Attempting to build libsaithrift with saithriftv2 from SAI fails.

#### How I did it

Added python-all and python-all-dev to bullseye slave container as python2 is a build dependency of thrift 0.14.1 which is a dependecy of saithriftv2

Added perl libraries to bullseye slave container which are build dependencies of saithriftv2

Altered thrift 0.14.1 patch set to remove python-dev from the build dependencies since it is covered by python2-dev which is installed by python-all-dev.

python-dev is treated differently in bullseye and installs python-dev-is-python-2 which is not a desirable package to install on the slave container (and not needed to successfully compile thrift)

#### How to verify it

Compile libsaithrift with `SAITHRIFTV2=y` build option

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix build dependencies for saithriftv2 in bullseye

#### A picture of a cute animal (not mandatory but encouraged)
TBD