### PR TITLE
Add logging for slave container builds

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -246,12 +246,18 @@ endif
 
 endif
 
+SPLIT_LOG = | tee
+
+DOCKER_BASE_LOG = $(SLAVE_DIR)/$(SLAVE_BASE_IMAGE)_$(SLAVE_BASE_TAG).log
+DOCKER_LOG = $(SLAVE_DIR)/$(SLAVE_IMAGE)_$(SLAVE_TAG).log
+
+
 DOCKER_BASE_BUILD = docker build --no-cache \
 		    -t $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) \
 		    --build-arg http_proxy=$(http_proxy) \
 		    --build-arg https_proxy=$(https_proxy) \
 		    --build-arg no_proxy=$(no_proxy) \
-		    $(SLAVE_DIR)
+		    $(SLAVE_DIR) $(SPLIT_LOG) $(DOCKER_BASE_LOG)
 
 DOCKER_BASE_PULL = docker pull \
 			$(REGISTRY_SERVER):$(REGISTRY_PORT)/$(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)
@@ -264,7 +270,7 @@ DOCKER_BUILD = docker build --no-cache \
                --build-arg slave_base_tag_ref=$(SLAVE_BASE_TAG) \
 	       -t $(SLAVE_IMAGE):$(SLAVE_TAG) \
 	       -f $(SLAVE_DIR)/Dockerfile.user \
-	       $(SLAVE_DIR)
+	       $(SLAVE_DIR) $(SPLIT_LOG) $(DOCKER_LOG)
 
 SONIC_BUILD_INSTRUCTION :=  make \
                            -f slave.mk \


### PR DESCRIPTION
#### Why I did it

No logs currently exist for sonic-save-X containers which makes it difficult to debug.

#### How I did it

Altered Makefile.work to create logs in the sonic-slave-X folder while still displaying the log to the screen to prevent interfering with any existing tooling. 

#### How to verify it

Do `make configure` and verify that logs show up in `sonic-slave-buster/` and `sonic-slave-bullseye/`

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add logging for slave container builds

#### A picture of a cute animal (not mandatory but encouraged)
TBD
