### PR TITLE
Upgrade libasan to version 6 in docker-syncd-mlnx to align with bullseye libasan

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -33,7 +33,7 @@ RUN apt-get update && \
         python3-dev \
         python-is-python3 \
 {%- if ENABLE_ASAN == "y" %}
-        libasan5 \
+        libasan6 \
 {%- endif %}
         python3-setuptools
 


### PR DESCRIPTION
#### Why I did it

syncd is linking to libasan v6 during build after the bullseye upgrade (https://github.com/Azure/sonic-buildimage/pull/10580) and libasan v5 is installed in the syncd container for the mellanox platform which is causing runtime errors.

#### How I did it

Install libasan6 on docker-syncd-mlnx

#### How to verify it

Build sonic with `ENABLE_ASAN=y` and verify syncd starts successfully. 

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Upgrade libasan to version 6 in docker-syncd-mlnx to align with bullseye libasan

#### A picture of a cute animal (not mandatory but encouraged)
TBD
